### PR TITLE
feat(db): Add pagination for mongodb

### DIFF
--- a/db/mongodb/mongo.go
+++ b/db/mongodb/mongo.go
@@ -108,8 +108,9 @@ func (r *formRepository) GetForms(model *db.GetFormsModel) (*db.FormsModel, erro
 	countFilter := bson.D{}
 	copy(countFilter, filter)
 
+	opts := options.Find().SetLimit(model.Limit).SetSkip(model.Skip)
 	forms := make([]*db.FormModel, 0)
-	cursor, err := collection.Find(r.context, filter)
+	cursor, err := collection.Find(r.context, filter, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -125,9 +126,8 @@ func (r *formRepository) GetForms(model *db.GetFormsModel) (*db.FormsModel, erro
 			return nil, err
 		}
 		form := db.FormModel{
-			ID:        bsonForm["_id"].(bson.ObjectID).Hex(),
-			Name:      bsonForm["name"].(string),
-			Fieldsets: bsonForm["fieldsets"].([]db.FieldSetModel),
+			ID:   bsonForm["_id"].(bson.ObjectID).Hex(),
+			Name: bsonForm["name"].(string),
 		}
 		forms = append(forms, &form)
 	}

--- a/graph/arguments.go
+++ b/graph/arguments.go
@@ -4,6 +4,46 @@ import (
 	"github.com/graphql-go/graphql"
 )
 
+func getIntOrDefault(raw any, defaultValue int) int {
+	val, ok := raw.(int)
+	if !ok {
+		return defaultValue
+	}
+
+	return val
+}
+
+func getIntPointerOrDefault(raw any, defaultValue *int) *int {
+	intVal, ok := raw.(int)
+	if !ok {
+		ptrInt, ok := raw.(*int)
+		if !ok {
+			return defaultValue
+		}
+		return ptrInt
+	}
+
+	return &intVal
+}
+
+func getStringOrDefault(raw any, defaultValue string) string {
+	val, ok := raw.(string)
+	if !ok {
+		return defaultValue
+	}
+
+	return val
+}
+
+func getBoolOrDefault(raw any, defaultValue bool) bool {
+	val, ok := raw.(bool)
+	if !ok {
+		return defaultValue
+	}
+
+	return val
+}
+
 var (
 	LabelInputConfig = graphql.InputObjectFieldConfig{
 		Type:         graphql.String,

--- a/graph/constants.go
+++ b/graph/constants.go
@@ -1,0 +1,6 @@
+package graph
+
+const (
+	DEFAULT_LIMIT_VALUE int = 10
+	DEFAULT_PAGE_VALUE  int = 0
+)

--- a/graph/mutations.go
+++ b/graph/mutations.go
@@ -8,46 +8,6 @@ import (
 	"github.com/squishedfox/fictional-fiesta/db"
 )
 
-func getIntOrDefault(raw any, defaultValue int) int {
-	val, ok := raw.(int)
-	if !ok {
-		return defaultValue
-	}
-
-	return val
-}
-
-func getIntPointerOrDefault(raw any, defaultValue *int) *int {
-	intVal, ok := raw.(int)
-	if !ok {
-		ptrInt, ok := raw.(*int)
-		if !ok {
-			return defaultValue
-		}
-		return ptrInt
-	}
-
-	return &intVal
-}
-
-func getStringOrDefault(raw any, defaultValue string) string {
-	val, ok := raw.(string)
-	if !ok {
-		return defaultValue
-	}
-
-	return val
-}
-
-func getBoolOrDefault(raw any, defaultValue bool) bool {
-	val, ok := raw.(bool)
-	if !ok {
-		return defaultValue
-	}
-
-	return val
-}
-
 func mapFieldSetInput(raw map[string]any) (db.FormInputModel, error) {
 	inputModel := db.FormInputModel{}
 

--- a/graph/queries.go
+++ b/graph/queries.go
@@ -1,10 +1,7 @@
 package graph
 
 import (
-	"errors"
-
 	"github.com/graphql-go/graphql"
-	"github.com/squishedfox/fictional-fiesta/db"
 )
 
 var (
@@ -43,21 +40,7 @@ var (
 						Type:         graphql.Int,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (any, error) {
-					repository := p.Context.Value(db.FormsRepositoryContextKey).(db.FormsRepository)
-					if repository == nil {
-						return nil, errors.New("Could not fetch repository from user context")
-					}
-
-					result, err := repository.GetForms(&db.GetFormsModel{})
-					if err != nil {
-						return nil, err
-					}
-					return &struct {
-						Results []*db.FormModel `json:"results"`
-						Count   int64           `json:"count"`
-					}{result.Forms, result.Count}, nil
-				},
+				Resolve: formListResolver,
 			},
 		},
 	})

--- a/graph/resolvers.go
+++ b/graph/resolvers.go
@@ -1,0 +1,34 @@
+package graph
+
+import (
+	"errors"
+
+	"github.com/graphql-go/graphql"
+	"github.com/squishedfox/fictional-fiesta/db"
+)
+
+func formListResolver(p graphql.ResolveParams) (any, error) {
+	repository := p.Context.Value(db.FormsRepositoryContextKey).(db.FormsRepository)
+	if repository == nil {
+		return nil, errors.New("Could not fetch repository from user context")
+	}
+
+	limit := getIntOrDefault(p.Args["limit"], DEFAULT_LIMIT_VALUE)
+	page := getIntOrDefault(p.Args["page"], DEFAULT_PAGE_VALUE)
+	skip := limit * page
+
+	result, err := repository.GetForms(&db.GetFormsModel{
+		Limit: int64(limit),
+		Skip:  int64(skip),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &struct {
+		Results []*db.FormModel `json:"results"`
+		Count   int64           `json:"count"`
+	}{
+		result.Forms,
+		result.Count,
+	}, nil
+}


### PR DESCRIPTION
# Change(s):

- Adds pagination capabilities for when searching for documents

## Testing

1. Start application
2. Go to http://localhost:8080/graphql
3. Paste the below into the query section

```graphql
query filterForms($id: String, $page: Int, $limit: Int) {
  list(id: $id, page: $page, limit: $limit) {
    count,
    results {
      id,
      fieldsets {
        fields {
          ordinal,
          name,
          type,
        }
        legend,
      }
    }
  }
}
```

4. Paste the below JSON into the Variables Section

```graphql
{
  "page": 0
}
```

5. Notice that you get results back
6. Change the Variables to have a page way in the future

```graphql
{
  "page": 10
}
```

7. Notice you get counts back but you do not get

